### PR TITLE
[JIRA] create_agile_board method adapted for Jira Server

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -3391,13 +3391,11 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         :param name: str
         :param type: str, scrum or kanban
         :param filter_id: int
-        :param location: dict, Optional. Default is user
+        :param location: dict, Optional. Only specify this for Jira Cloud!
         """
         data = {"name": name, "type": type, "filterId": filter_id}
         if location:
             data["location"] = location
-        else:
-            data["location"] = {"type": "user"}
         url = "rest/agile/1.0/board"
         return self.post(url, data=data)
 


### PR DESCRIPTION
The `location` parameter of the `create_agile_board` must not be sent
for the Jira Server edition.
This parameter is not supported as per the REST API documentation and
throws an error if sent anyway.